### PR TITLE
feat: 회원가입 페이지 재구현 / test: 프론트-백엔드 연결 테스트

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "apptive-18th-team4-frontend",
   "version": "0.1.0",
   "private": true,
-  "proxy" : "http://localhost:8080",
+  "proxy" : "http://3.34.82.40:8080",
   "dependencies": {
     "@react-oauth/google": "^0.8.0",
     "@testing-library/jest-dom": "^5.16.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "apptive-18th-team4-frontend",
   "version": "0.1.0",
   "private": true,
-  "proxy" : "http://3.34.82.40:8080",
   "dependencies": {
     "@react-oauth/google": "^0.8.0",
     "@testing-library/jest-dom": "^5.16.5",
@@ -16,6 +15,7 @@
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },
+  "proxy" : "http://3.34.82.40:8080",
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/src/pages/login/login.js
+++ b/src/pages/login/login.js
@@ -3,16 +3,8 @@ import {useNavigate} from 'react-router-dom'
 import axios from 'axios'
 
 export default function Login() {
-    const [memberId, setID] = useState('');
+    const [email, setEmail] = useState('');
     const [password, setPW] = useState('');
-
-    const handleID = (e) => {
-        setID(e.target.value)
-    }
-    
-    const handlePW = (e) => {
-        setPW(e.target.value)
-    }
 
     const getLoginInfo = () => {
         const accessToken = localStorage.getItem('accessToken')
@@ -32,11 +24,11 @@ export default function Login() {
 
     const handleLogin = (e) => {
         e.preventDefault()
-        if (memberId.length === 0) alert("아이디를 입력해주세요")
+        if (email.length === 0) alert("아이디를 입력해주세요")
         else if (password.length === 0) alert("비밀번호를 입력해주세요")
         else {
-            axios.post("url", {
-                    memberId: memberId, 
+            axios.post("http://3.34.82.40:8080/auth/login", {
+                    email: email, 
                     password: password
                 }, { headers: { "Content-Type": `application/json`} })
             .then({onLoginSuccess}) 
@@ -58,7 +50,7 @@ export default function Login() {
             isRefreshing = true;
         }
     
-        axios.post("재발급 url", {
+        axios.post("http://3.34.82.40:8080/auth/reissue", {
                   accessToken: accessToken,
                   refreshToken: refreshToken
                 }, { headers: { 'Content-Type': 'application/json'} })
@@ -96,14 +88,14 @@ export default function Login() {
     
     return (
         <div className='login'>
-            <div className='enterID'>
-                <label htmlFor='memberId'>아이디</label>
-                <input name='memberId' onChange={handleID} value={memberId} className="memberId"/>
+            <div className='enterEmail'>
+                <label htmlFor='email'>아이디</label>
+                <input name='email' onChange={e => setEmail(e.target.value)} value={email} className="email"/>
             </div>
 
             <div className='enterPW'>
                 <label htmlFor='password'>비밀번호</label>
-                <input name='password' onChange={handlePW} value={password} className="password"/>
+                <input name='password' onChange={e => setPW(e.target.value)} value={password} className="password"/>
             </div>
 
             <div>

--- a/src/pages/login/login.js
+++ b/src/pages/login/login.js
@@ -30,7 +30,7 @@ export default function Login() {
             axios.post("http://3.34.82.40:8080/auth/login", {
                     email: email, 
                     password: password
-                }, { headers: { "Content-Type": `application/json`} })
+                }, { headers: { 'Content-Type': 'application/json'} })
             .then({onLoginSuccess}) 
             .catch(function(error) {
                 console.log(error)

--- a/src/pages/signUp/signUp.js
+++ b/src/pages/signUp/signUp.js
@@ -2,60 +2,38 @@ import {useState} from 'react'
 import axios from 'axios'
 
 export default function SignUp () {
-    const [memberId, setID] = useState('');
-    const [password, setPW] = useState('');
-    const [checkedPassword, setPW2] = useState('');
-    const [state, setState] = useState('');
-    const [keyword, setKeyword] = useState('');
-    
-    const handleID = (e) => {
-        setID(e.target.value)
-    }
-    
-    const handlePW = (e) => {
-        setPW(e.target.value)
-    }
+    const [email, setEmail] = useState('')
+    const [password, setPW] = useState('')
+    const [checkedPassword, setPW2] = useState('')
+    const [nickname, setNickname] = useState('')
+    const [findQuesNum, setQuesNum] = useState('')
+    const [findAnswer, setAnswer] = useState('')
+    const [isChecked, setIsChecked] = useState(false);
+    const question_list = ['선택', '내가 다닌 초등학교는?', '인상 깊게 읽은 책 이름은?', '내 별명은?']
 
-    const handlePW2 = (e) => {
-        setPW2(e.target.value)
-    }
-
-    const state_list = ['선택', '대학생', '대학원생', '휴학생', '신입생']
-    const [selectedState, setSelectedState] = useState('')
-
-    // 사용자의 state 추출하기
-    const handleState = (e) => {
-        e.preventDefault()
-        const getState = e.target.value
-        setSelectedState(getState)
-        if (getState === "대학생") setState(1)
-        else if (getState === "대학원생") setState(2)
-        else if (getState === "휴학생") setState(3)
-        else if (getState === "신입생") setState(4)
-        else if (getState === "선택") {
-            setState('')
-            alert("신분을 선택해주세요")
-        }
-    }
-
-    const handleKeyword = (e) => {
-        setKeyword(e.target.value)
-      };
+    console.log(email)
+    console.log(password)
+    console.log(nickname)
+    console.log(findQuesNum)
+    console.log(findAnswer)
     
     const handleSignup = (e) => {
         e.preventDefault()
-        if (memberId.length === 0) alert("아이디를 입력해주세요")
+        if (email.length === 0) alert("아이디를 입력해주세요")
         else if (password.length === 0) alert("비밀번호를 입력해주세요")
         else if (password !== checkedPassword) alert ("비밀번호가 일치하지 않습니다")
+        else if (findQuesNum == 0 && findAnswer.length !== 0) alert("아이디 확인 질문을 선택해주세요")
+        else if (findQuesNum != 0 && findAnswer.length === 0) alert("아이디 확인 질문의 답을 입력해주세요")
+        else if (!isChecked) alert("약관에 동의하지 않을 경우, 회원가입이 어렵습니다.")
         else {
             const form = new FormData()
-            form.append('memberId', memberId)
+            form.append('email', email)
             form.append('password', password)
-            form.append('checkedPassword', checkedPassword)
-            form.append('state', state)
-            form.append('keyword', keyword)
+            form.append('nickname', nickname)
+            form.append('findQuesNum', findQuesNum)
+            form.append('findAnswer', findAnswer)
 
-            axios.post("url", form, { headers: { "Content-Type": `application/json`} })
+            axios.post("http://3.34.82.40:8080/auth/signup", form, { headers: { "Content-Type": `application/json`} })
             .then(function(response) {
                 console.log(response)
             }) .catch(function(error) {
@@ -66,37 +44,47 @@ export default function SignUp () {
 
     return (
         <div className='signUp'>
-            <div className='enterID'>
-                <label htmlFor='memberId'>아이디</label>
-                <input name='memberId' onChange={handleID} value={memberId} className="memberId"/>
+            <div className='enterEmail'>
+                <label htmlFor='email'>아이디</label>
+                <input name='email' onChange={e => setEmail(e.target.value)} value={email} type="email" className="email"/>
             </div>
 
             <div className='enterPW'>
                 <label htmlFor='password'>비밀번호</label>
-                <input name='password' onChange={handlePW} value={password} className="password"/>
+                <input name='password' onChange={e => setPW(e.target.value)} value={password} className="password"/>
             </div>
 
             <div className='checkPW'>
                 <label htmlFor='check_password'>비밀번호 확인</label>
-                <input name='checkedPassword' onChange={handlePW2} value={checkedPassword} className="password"/>
+                <input name='checkedPassword' onChange={e => setPW2(e.target.value)} value={checkedPassword} className="password2"/>
+            </div>
+
+            <div className='enterNickname'>
+                <label htmlFor='nickname'>닉네임</label>
+                <input name='nickname' onChange={e => setNickname(e.target.value)} value={nickname} className="nickname"/>
             </div>
 
             <div className='selectMajor'>
-                <label htmlFor='state'>신분</label>
-                <select name={state} onChange={handleState} value={selectedState} className="major">
-                    {state_list.map((major) => (
-                        <option value={major} key={major}> {major} </option>
+                <label htmlFor='state'>아이디 확인 질문</label>
+                <select name={findQuesNum} onChange={e => setQuesNum(parseInt(e.target.value, 10))} value={findQuesNum} className="major">
+                    {question_list.map((question, idx) => (
+                        <option value={idx} key={idx}> {question} </option>
                     ))}
                 </select>
             </div>
 
-            <div className='addKeyword'>
-                <label htmlFor='keyword'>키워드</label>
-                <input name='keyword' onChange={handleKeyword} value={keyword} className="keyword"/>
+            <div className='enterAnswer'>
+                <label htmlFor='findAnswer'>답</label>
+                <input name='findAnswer' onChange={e => setAnswer(e.target.value)} value={findAnswer} className="findAnswer"/>
+            </div>
+
+            <div className='agreement'>
+                <input type="checkbox" checked={isChecked} onChange={e => setIsChecked(e.target.checked)} className="agreement"/>
+                <label htmlFor='agreement'>이용약관 및 개인정보 취급방침에 동의합니다.</label>
             </div>
 
             <div>
-                <button onClick={handleSignup}>확인</button> 
+                <button onClick={handleSignup}>회원가입</button> 
             </div>
         </div>
     )

--- a/src/pages/signUp/signUp.js
+++ b/src/pages/signUp/signUp.js
@@ -19,11 +19,11 @@ export default function SignUp () {
     
     const handleSignup = (e) => {
         e.preventDefault()
-        if (email.length === 0) alert("아이디를 입력해주세요")
-        else if (password.length === 0) alert("비밀번호를 입력해주세요")
-        else if (password !== checkedPassword) alert ("비밀번호가 일치하지 않습니다")
-        else if (findQuesNum == 0 && findAnswer.length !== 0) alert("아이디 확인 질문을 선택해주세요")
-        else if (findQuesNum != 0 && findAnswer.length === 0) alert("아이디 확인 질문의 답을 입력해주세요")
+        if (email.length === 0) alert("아이디를 입력해주세요.")
+        else if (password.length < 6) alert("비밀번호는 6자리 이상으로 설정해주세요.")
+        else if (password !== checkedPassword) alert ("비밀번호가 일치하지 않습니다.")
+        else if (findQuesNum == 0 && findAnswer.length !== 0) alert("아이디 확인 질문을 선택해주세요.")
+        else if (findQuesNum != 0 && findAnswer.length === 0) alert("아이디 확인 질문의 답을 최소 1자 이상 입력해주세요.")
         else if (!isChecked) alert("약관에 동의하지 않을 경우, 회원가입이 어렵습니다.")
         else {
             const form = new FormData()
@@ -33,7 +33,7 @@ export default function SignUp () {
             form.append('findQuesNum', findQuesNum)
             form.append('findAnswer', findAnswer)
 
-            axios.post("http://3.34.82.40:8080/auth/signup", form, { headers: { "Content-Type": `application/json`} })
+            axios.post("http://3.34.82.40:8080/auth/signup", form, { headers: { 'Content-Type': 'application/json'} })
             .then(function(response) {
                 console.log(response)
             }) .catch(function(error) {
@@ -44,48 +44,50 @@ export default function SignUp () {
 
     return (
         <div className='signUp'>
-            <div className='enterEmail'>
-                <label htmlFor='email'>아이디</label>
-                <input name='email' onChange={e => setEmail(e.target.value)} value={email} type="email" className="email"/>
-            </div>
+            <form onSubmit={handleSignup}>
+                <div className='enterEmail'>
+                    <label htmlFor='email'>아이디</label>
+                    <input name='email' onChange={e => setEmail(e.target.value)} value={email} type="email" className="email"/>
+                </div>
 
-            <div className='enterPW'>
-                <label htmlFor='password'>비밀번호</label>
-                <input name='password' onChange={e => setPW(e.target.value)} value={password} className="password"/>
-            </div>
+                <div className='enterPW'>
+                    <label htmlFor='password'>비밀번호</label>
+                    <input name='password' onChange={e => setPW(e.target.value)} value={password} className="password"/>
+                </div>
 
-            <div className='checkPW'>
-                <label htmlFor='check_password'>비밀번호 확인</label>
-                <input name='checkedPassword' onChange={e => setPW2(e.target.value)} value={checkedPassword} className="password2"/>
-            </div>
+                <div className='checkPW'>
+                    <label htmlFor='check_password'>비밀번호 확인</label>
+                    <input name='checkedPassword' onChange={e => setPW2(e.target.value)} value={checkedPassword} className="password2"/>
+                </div>
 
-            <div className='enterNickname'>
-                <label htmlFor='nickname'>닉네임</label>
-                <input name='nickname' onChange={e => setNickname(e.target.value)} value={nickname} className="nickname"/>
-            </div>
+                <div className='enterNickname'>
+                    <label htmlFor='nickname'>닉네임</label>
+                    <input name='nickname' onChange={e => setNickname(e.target.value)} value={nickname} className="nickname"/>
+                </div>
 
-            <div className='selectMajor'>
-                <label htmlFor='state'>아이디 확인 질문</label>
-                <select name={findQuesNum} onChange={e => setQuesNum(parseInt(e.target.value, 10))} value={findQuesNum} className="major">
-                    {question_list.map((question, idx) => (
-                        <option value={idx} key={idx}> {question} </option>
-                    ))}
-                </select>
-            </div>
+                <div className='selectMajor'>
+                    <label htmlFor='state'>아이디 확인 질문</label>
+                    <select name={findQuesNum} onChange={e => setQuesNum(parseInt(e.target.value, 10))} value={findQuesNum} className="major">
+                        {question_list.map((question, idx) => (
+                            <option value={idx} key={idx}> {question} </option>
+                        ))}
+                    </select>
+                </div>
 
-            <div className='enterAnswer'>
-                <label htmlFor='findAnswer'>답</label>
-                <input name='findAnswer' onChange={e => setAnswer(e.target.value)} value={findAnswer} className="findAnswer"/>
-            </div>
+                <div className='enterAnswer'>
+                    <label htmlFor='findAnswer'>답</label>
+                    <input name='findAnswer' onChange={e => setAnswer(e.target.value)} value={findAnswer} className="findAnswer"/>
+                </div>
 
-            <div className='agreement'>
-                <input type="checkbox" checked={isChecked} onChange={e => setIsChecked(e.target.checked)} className="agreement"/>
-                <label htmlFor='agreement'>이용약관 및 개인정보 취급방침에 동의합니다.</label>
-            </div>
+                <div className='agreement'>
+                    <input type="checkbox" checked={isChecked} onChange={e => setIsChecked(e.target.checked)} className="agreement"/>
+                    <label htmlFor='agreement'>이용약관 및 개인정보 취급방침에 동의합니다.</label>
+                </div>
 
-            <div>
-                <button onClick={handleSignup}>회원가입</button> 
-            </div>
+                <div>
+                    <button type="submit">회원가입</button> 
+                </div>
+            </form>
         </div>
     )
 }


### PR DESCRIPTION
# 변경점 👍 
- 변경된 기획안에 따라 회원가입 페이지 재구현 (아이디 찾기 질문 선택 및 답변 입력칸, 이용약관 동의 체크박스 추가)
- 회원가입 시 아래와 같은 상황에서 경고창 띄우기
    - 아이디를 입력하지 않거나 입력한 값이 이메일 형식이 아닌 경우
    - 비밀번호가 6자리 이상이 아닌 경우
    - 비밀번호와 비밀번호 확인 칸의 값이 다른 경우
    - 아이디 찾기 질문은 선택했으나 그에 대한 답변을 입력하지 않은 경우
    - 반대로 답변은 입력했으나 아이디 찾기 질문은 선택하지 않은 경우
    - 약관에 동의하지 않은 경우(체크박스 체크 여부 확인)
- 프론트와 백엔드 연결 테스트를 위한 proxy 설정 및 axios로 요청 보내는 코드 작성
 
# 리팩토링 🛠
- 이메일, 비밀번호 값 추출 함수 간소화
- axios 사용 시 쌍따옴표와 백틱 혼용 코드 수정

# 비고 ✏
백엔드에서 CORS 문제를 아직 해결하지 못해 해결되는 대로 연결 테스트 진행할 예정이다.